### PR TITLE
Allow to access to all data object from decoded token

### DIFF
--- a/lib/passport-opentoken/strategy.js
+++ b/lib/passport-opentoken/strategy.js
@@ -128,9 +128,9 @@ Strategy.prototype.authenticate = function (req, options) {
     }
 
     if (self._passReqToCallback) {
-      self._verify(req, data.subject, verified);
+      self._verify(req, data, verified);
     } else {
-      self._verify(data.subject, verified);
+      self._verify(data, verified);
     }
 
   });


### PR DESCRIPTION
Hi,

Is it possible to switch a little bit approach and allow to access to all data object from decoded token?

Now, it is only allow to get to **data.subject** property, but I think it would be better if we could resolve all data object. For example in our case in token we encoded more personal data (like email, firstname, lastname) that we would like to use after log in.